### PR TITLE
Clear gym defenders on team change

### DIFF
--- a/decoder/gym.go
+++ b/decoder/gym.go
@@ -624,6 +624,10 @@ func createGymWebhooks(oldGym *Gym, gym *Gym, areas []geo.AreaName) {
 func saveGymRecord(ctx context.Context, db db.DbDetails, gym *Gym) {
 	oldGym, _ := GetGymRecord(ctx, db, gym.Id)
 
+	if oldGym != nil && oldGym.TeamId.ValueOrZero() != gym.TeamId.ValueOrZero() {
+		gym.Defenders = null.NewString("", false)
+	}
+
 	now := time.Now().Unix()
 	if oldGym != nil && !hasChangesGym(oldGym, gym) {
 		if oldGym.Updated > now-900 {


### PR DESCRIPTION
## Summary
- clear stored gym defenders when the gym changes teams before saving the update

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4ed6f46b08320a49c75449854e2ea