### PR TITLE
Reset gym defenders when team changes

### DIFF
--- a/decoder/gym.go
+++ b/decoder/gym.go
@@ -204,6 +204,9 @@ func (gym *Gym) updateGymFromFort(fortData *pogo.PokemonFortProto, cellId uint64
 		})
 		gym.GuardingPokemonDisplay = null.StringFrom(string(display))
 	}
+	if !gym.TeamId.Valid || gym.TeamId.Int64 != int64(fortData.Team) {
+		gym.Defenders = null.NewString("", false)
+	}
 	gym.TeamId = null.IntFrom(int64(fortData.Team))
 	if fortData.GymDisplay != nil {
 		gym.AvailableSlots = null.IntFrom(int64(fortData.GymDisplay.SlotsAvailable))


### PR DESCRIPTION
## Summary
- clear a gym's cached defender list when the fort's team assignment changes
- leave remaining gym update logic untouched so downstream callers benefit automatically

## Testing
- go test ./decoder/... *(hangs for several minutes in CI environment, command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68d587f5fd8c832098e289e501e71b98